### PR TITLE
database settings updated

### DIFF
--- a/pasteme/settings.py
+++ b/pasteme/settings.py
@@ -82,14 +82,15 @@ WSGI_APPLICATION = 'pasteme.wsgi.application'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-        # 'OPTIONS': {
-        #     'ssl': {'ca': config('MYSQL_ATTR_SSL_CA')},
-        #     'charset': 'utf8mb4',
-        #  }
-    }
+  'default': {
+    'ENGINE': 'django_psdb_engine',
+    'NAME': config('DB_DATABASE'),
+    'HOST': config('DB_HOST'),
+    'PORT': config('DB_PORT'),
+    'USER': config('DB_USER'),
+    'PASSWORD': config('DB_PASSWORD'),
+    'OPTIONS': {'ssl': {'ca': config('MYSQL_ATTR_SSL_CA')}, 'charset': 'utf8mb4'}
+  }
 }
 
 # Password validation


### PR DESCRIPTION
The default DB settings changed to PlanetScale one. (User needs to either create a `.env` file and add the credentials or override the `DATABASES` variable in `local_settings.py`)