### PR TITLE
ADD: Code Comments, UPDATE: Modal state saved on local storage

### DIFF
--- a/snippet/static/js/darkmode.js
+++ b/snippet/static/js/darkmode.js
@@ -1,18 +1,22 @@
+// This is the very first file (scripts) that is executed when the page
+// is loading. It is used to determine if the user prefers dark mode or
+// not. If yes, it will add the "dark" class to the html element.
 (function () {
-    let dark_mode = true;
-    let html_element = document.getElementsByTagName("html")[0];
+  let dark_mode = true;
+  let html_element = document.getElementsByTagName("html")[0];
 
-    // Disable dark mode if the user's device is not set to dark mode
-    if (
-        localStorage.theme === "dark" ||
-        (!("theme" in localStorage) &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-    ) {
-        html_element.classList.add("dark");
-    } else {
-        html_element.classList.remove("dark");
-        dark_mode = false;
-    }
+  // Disable dark mode if the user's device is not set to dark mode
+  if (
+    localStorage.theme === "dark" ||
+    (!("theme" in localStorage) &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches)
+  ) {
+    html_element.classList.add("dark");
+  } else {
+    html_element.classList.remove("dark");
+    dark_mode = false;
+  }
 
-    localStorage.theme = dark_mode ? "dark" : "light";
+  // the value will be saved for future visits
+  localStorage.theme = dark_mode ? "dark" : "light";
 })();

--- a/snippet/static/js/home.js
+++ b/snippet/static/js/home.js
@@ -1,5 +1,10 @@
 $(function () {
-  if (sessionStorage.getItem("show_modal") === "true") {
+  if (localStorage.show_modal === "true") {
+    console.log("show modal");
+    // This property is active on the body element by default, this is
+    // used to block user from scrolling the page while the modal is
+    // active. It gets removed when the loading screen is removed, so I
+    // need to add it back. @loading.js
     $("body").addClass("overflow-hidden");
   }
 
@@ -71,14 +76,27 @@ $(function () {
     }
   }
 
+  // If a modal is being shown to the user, it has a X button that
+  // can be used to close the modal.
   $("#modal-close").on("click", function () {
     $("#modal").hide();
+
+    // Make page scrollable again.
     $("body").removeClass("overflow-hidden");
-    sessionStorage.setItem("show_modal", "false");
+
+    // Save this preference to the storage that modal doesn't show
+    // again. (if there be a new modal to show, it will be shown because
+    // the modal_id is also saved in storage @home.html in the inline scripts)
+    localStorage.show_modal = 'false';
+
+    // If a modal is being shown, all other background animations are
+    // blocked until the user closes the modal. I need to play them when
+    // the modal is closed.
     play_page_animations();
   });
 
-  if (sessionStorage.getItem("show_modal") === "false") {
+  if (localStorage.show_modal === "false") {
+    // Hide the modal element if the user has already closed it.
     $("#modal").hide();
     play_page_animations();
   }

--- a/snippet/static/js/interactive.js
+++ b/snippet/static/js/interactive.js
@@ -10,6 +10,8 @@
     $("#menu").toggleClass("menu-open");
   });
 
+  // This function needs to calculate the display property of the navbar
+  // every time the user scrolls.
   window.onscroll = function () {
     fixNavbar();
   };
@@ -31,7 +33,7 @@
       // we need it back
       setTimeout(function () {
         navbar.classList.add("transition-colors", "duration-300");
-      }, 100);
+      }, 100); // This 100ms delay is needed for the color-change to take effect
     } else {
       main.style.paddingTop = 0;
       navbar.classList.remove("sticky");

--- a/snippet/static/js/loading.js
+++ b/snippet/static/js/loading.js
@@ -1,10 +1,18 @@
 $(function () {
-    // hides the loading screen
-    $("body").removeClass("overflow-hidden");
-    $("#loading-msg").addClass("loaded");
+  // Body has this property by default, this is used to block user from
+  // scrolling the page while the loading screen is active.
+  $("body").removeClass("overflow-hidden");
 
-    // removes the loading screen after 1 second
-    setTimeout(function () {
-        $("#loading-msg").hide();
-    }, 1000);
+  // This class moves the element out of the viewport by "slide-out"
+  // animation defined in the CSS file. @extra.css
+  $("#loading-msg").addClass("loaded");
+
+  // removes the loading screen after 1 second, if we omit this step
+  // the loading screen will be visible while taking screenshots
+  // because the "loaded" class will only add the "slide-out"
+  // animation to the element which translates it's Y-position and not
+  // hiding the element completely.
+  setTimeout(function () {
+    $("#loading-msg").hide();
+  }, 1000); // I wait for 1 second to make sure the loading screen is fully out of view
 });

--- a/snippet/templates/home.html
+++ b/snippet/templates/home.html
@@ -1,6 +1,9 @@
 {% extends 'base/_base.html' %}
 {% load static %}
 {% load compress %}
+{% block addon_style %}
+    <link rel="stylesheet" href="{% static 'css/asciinema-player.css' %}"/>
+{% endblock addon_style %}
 {% block header_msg %}
     <div class="w-full relative select-none">
         <canvas class="w-full h-full absolute left-0 top-0 -z-10" id="banner"></canvas>
@@ -25,18 +28,24 @@
     {% if modal %}
         {% compress js %}
             <script>
-                let show_modal = sessionStorage.getItem('show_modal');
-                let modal_id = sessionStorage.getItem('modal_id');
+                // If there is a modal to show, check if the user have already seen it or not,
+                // if not, show it. If the user have seen it, check if it's a new modal or not,
+                // if it's a new modal, show it.
+                let show_modal = localStorage.show_modal
+                let modal_id = localStorage.modal_id
 
-                if (show_modal === null || (show_modal === 'false' && modal_id != {{ modal.pk }})) {
-                    sessionStorage.setItem("show_modal", "true");
-                    sessionStorage.setItem("modal_id", {{ modal.pk }});
+                if (show_modal == null || (show_modal === 'false' && modal_id != {{ modal.pk }})) {
+                    localStorage.show_modal = 'true';
+                    localStorage.modal_id = '{{ modal.pk }}';
                 }
             </script>
         {% endcompress %}
     {% else %}
         {% compress js %}
-            <script>sessionStorage.setItem("show_modal", "false");</script>
+            <script>
+                // If there is no modal, then disable the modal feature.
+                localStorage.show_modal = 'false';
+            </script>
         {% endcompress %}
     {% endif %}
     {% include "modals/modal.html" with modal=modal %}

--- a/templates/base/_base.html
+++ b/templates/base/_base.html
@@ -38,11 +38,13 @@
                   type="image/png"
                   sizes="32x32"
                   href="{% static 'img/fav32.png' %}"/>
+            <!--- These are the very first files that are loaded -->
             {% compress js file %}
                   <script src="{% static 'js/darkmode.js' %}"></script>
                   <script src="{% static 'js/cash.min.js' %}"></script>
                   <script src="{% static 'js/loading.js' %}"></script>
             {% endcompress %}
+            <!--- Common CSS style sheets required for all pages -->
             {% include "base/_css_tags.html" %}
             {% block addon_style %}
             {% endblock addon_style %}
@@ -66,7 +68,11 @@
             {% block footer_msg %}
             {% endblock footer_msg %}
             {% include "base/_footer.html" %}
+            <!--- Common JS scripts required for all pages -->
             <script src="{% static 'js/aos.js' %}"></script>
+            <!--- interactive.js handles DOM events related to the interactive elements on the page,
+                  these include the navbar (needs to be fixed on scroll), the darkmode toggle, and the
+                  menu toggle. It also handles initializing the AOS library. -->
             <script src="{% static 'js/interactive.js' %}"></script>
             {% block addon_script %}
             {% endblock addon_script %}

--- a/templates/base/_css_tags.html
+++ b/templates/base/_css_tags.html
@@ -9,5 +9,4 @@
       <link rel="stylesheet" href="{% static 'css/fonts.css' %}"/>
       <link rel="stylesheet" href="{% static 'css/extra.css' %}"/>
       <link rel="stylesheet" href="{% static 'css/aos.css' %}"/>
-      <link rel="stylesheet" href="{% static 'css/asciinema-player.css' %}"/>
 {% endcompress %}


### PR DESCRIPTION
Modals 'closed' state were being saved in session storage, which made the modal to be shown every time a user closes the browser tab. Now it's being saved in local storage.